### PR TITLE
smmu: Fix guest domain restart

### DIFF
--- a/meta-xt-domx/recipes-extended/xen/files/0001-smmu-Fix-guest-domain-restart.patch
+++ b/meta-xt-domx/recipes-extended/xen/files/0001-smmu-Fix-guest-domain-restart.patch
@@ -1,0 +1,53 @@
+From 2934f78b258f7a4e1d6bd77b7c9213dd3dde5a03 Mon Sep 17 00:00:00 2001
+From: Mykyta Poturai <mykyta_poturai@epam.com>
+Date: Wed, 15 Jun 2022 10:51:23 +0300
+Subject: [PATCH] smmu: Fix guest domain restart
+
+Move arm_smmu_master_alloc_smes from arm_smmu_add_device to
+arm_smmu_attach_dev. The reason for this is that add_device is called
+only once at the beginning of a lifetime of each device, but
+arm_smmu_master_free_smes is called in arm_smmu_detach_dev which happens
+every time the domain is destroyed. So after restarting the guest domain
+smes are freed and never allocated again.
+
+Signed-off-by: Mykyta Poturai <mykyta_poturai@epam.com>
+---
+ xen/drivers/passthrough/arm/smmu.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/xen/drivers/passthrough/arm/smmu.c b/xen/drivers/passthrough/arm/smmu.c
+index 18cc9e941f..e76bd504ed 100644
+--- a/xen/drivers/passthrough/arm/smmu.c
++++ b/xen/drivers/passthrough/arm/smmu.c
+@@ -1699,6 +1699,10 @@ static int arm_smmu_attach_dev(struct iommu_domain *domain, struct device *dev)
+ 	if (!cfg)
+ 		return -ENODEV;
+ 
++	ret = arm_smmu_master_alloc_smes(dev);
++	if (ret)
++		return ret;
++
+ 	return arm_smmu_domain_add_master(smmu_domain, cfg);
+ }
+ 
+@@ -2042,7 +2046,7 @@ static int arm_smmu_add_device(struct device *dev)
+ 	struct arm_smmu_master_cfg *cfg;
+ 	struct iommu_group *group;
+ 	void (*releasefn)(void *) = NULL;
+-	int ret;
++	int ret = 0;
+ 
+ 	smmu = find_smmu_for_device(dev);
+ 	if (!smmu)
+@@ -2094,7 +2098,7 @@ static int arm_smmu_add_device(struct device *dev)
+ 	iommu_group_add_device(group, dev);
+ 	iommu_group_put(group);
+ 
+-	return arm_smmu_master_alloc_smes(dev);
++	return ret;
+ }
+ 
+ #if 0 /* Xen: We don't support remove device for now. Will be useful for PCI */
+-- 
+2.25.1
+

--- a/meta-xt-domx/recipes-extended/xen/xen-source.inc
+++ b/meta-xt-domx/recipes-extended/xen/xen-source.inc
@@ -1,9 +1,12 @@
 LIC_FILES_CHKSUM = "file://COPYING;md5=419739e325a50f3d7b4501338e44a4e5"
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 XEN_URL ??= "git://github.com/xen-troops/xen.git;protocol=https;branch=xen-4.16rc-migration"
 XEN_REV ??= "${AUTOREV}"
 
-SRC_URI = "${XEN_URL}"
+SRC_URI = "${XEN_URL} \
+	file://0001-smmu-Fix-guest-domain-restart.patch \
+	"
 XEN_REL = "4.16"
 PV = "${XEN_REL}.0+git${SRCPV}"
 SRCREV = "${XEN_REV}"


### PR DESCRIPTION
Move arm_smmu_master_alloc_smes from arm_smmu_add_device to
arm_smmu_attach_dev. The reason for this is that add_device is called
only once at the beginning of a lifetime of each device, but
arm_smmu_master_free_smes is called in arm_smmu_detach_dev which happens
every time the domain is destroyed. So after restarting the guest domain
smes are freed and never allocated again.

Leave this patch until the upstream thread[1] resolves.

[1] https://lore.kernel.org/xen-devel/a19f7238f428deb610df643944f60e1e79e273cf.1651075797.git.rahul.singh@arm.com/

Signed-off-by: Mykyta Poturai <mykyta_poturai@epam.com>